### PR TITLE
Fix typo

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -6,7 +6,7 @@
 	 */
 	$.fn.navList = function() {
 
-		var	$this = $(this);
+		var	$this = $(this),
 			$a = $this.find('a'),
 			b = [];
 


### PR DESCRIPTION
Variables `$a` and `b` were created in global namespace due to semicolon instead of comma